### PR TITLE
Bower.json: correct version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "mixpanel",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "main": "mixpanel.js"
 }


### PR DESCRIPTION
Pretty minor, but I got this warning:

```
bower mixpanel#*              mismatch Version declared in the json (2.0.0) is different than the resolved one (2.2.0)
```
