### PR TITLE
point to new home in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-As of February 2015 the Mixpanel Bower package has been moved to the [official repo](https://github.com/mixpanel/mixpanel-js)
+As of February 2015 the Mixpanel Bower package has been moved to the [official repo](https://github.com/mixpanel/mixpanel-js).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
-# mixpanel
-
-Home for the bower version of the official [JavaScript Client](https://mixpanel.com/docs/integration-libraries/javascript).
-
-## Configuration
-
-`<script>mixpanel.init("YOUR TOKEN");</script>`
+As of February 2015 the Mixpanel Bower package has been moved to the [official repo](https://github.com/mixpanel/mixpanel-js)


### PR DESCRIPTION
Hi @drubin, many thanks for working with us on https://github.com/drubin/mixpanel-bower/issues/5 to transfer the Bower package. To avoid confusion, this patch changes the README to link to the official repo.